### PR TITLE
fixup skb_header_pointer buffer ‘otcph’ may be used uninitialized.

### DIFF
--- a/xt_SPOOFTCP.c
+++ b/xt_SPOOFTCP.c
@@ -95,6 +95,7 @@ static struct tcphdr * spooftcp_tcphdr_put(struct sk_buff *nskb, const struct tc
 static unsigned int spooftcp_tg4(struct sk_buff *oskb, const struct xt_action_param *par)
 {
 	const struct iphdr *oiph;
+	struct tcphdr otcphb;
 	struct tcphdr *otcph;
 	struct net *net;
 	struct dst_entry *dst;
@@ -115,7 +116,7 @@ static unsigned int spooftcp_tg4(struct sk_buff *oskb, const struct xt_action_pa
 		return XT_CONTINUE;
 
 	otcph = skb_header_pointer(oskb, ip_hdrlen(oskb), sizeof(struct tcphdr),
-			   otcph);
+			   &otcphb);
 	
 	if (unlikely(!otcph))
 		return XT_CONTINUE;
@@ -220,6 +221,7 @@ static unsigned int spooftcp_tg6(struct sk_buff *oskb, const struct xt_action_pa
 	__u8 proto;
 	int tcphoff;
 	unsigned int otcplen;
+	struct tcphdr otcphb;
 	struct tcphdr *otcph;
 	struct net *net;
 	struct dst_entry *dst;
@@ -258,7 +260,7 @@ static unsigned int spooftcp_tg6(struct sk_buff *oskb, const struct xt_action_pa
 	}
 
 	otcph = skb_header_pointer(oskb, tcphoff, sizeof(struct tcphdr),
-				   otcph);
+				   &otcphb);
 	
 	if (unlikely(!otcph))
 		return XT_CONTINUE;


### PR DESCRIPTION
**I am not familiar with the network subsystems of Linux and netfliter. If this patch is wrong, please forgive my recklessness.**

When I compile this module on Linux 4.19.67, some warnings have been generated。

```
  CC [M]  /home/lin/netfilter-spooftcp/xt_SPOOFTCP.o
In file included from ./include/linux/ip.h:20,
                 from ./include/linux/inetdevice.h:9,
                 from /home/lin/netfilter-spooftcp/xt_SPOOFTCP.c:7:
/home/lin/netfilter-spooftcp/xt_SPOOFTCP.c: In function ‘spooftcp_tg6’:
./include/linux/skbuff.h:3375:6: warning: ‘otcph’ may be used uninitialized in this function [-Wmaybe-uninitialized]
      skb_copy_bits(skb, offset, buffer, len) < 0)
      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/lin/netfilter-spooftcp/xt_SPOOFTCP.c:223:17: note: ‘otcph’ was declared here
  struct tcphdr *otcph;
                 ^~~~~
In file included from ./include/linux/ip.h:20,
                 from ./include/linux/inetdevice.h:9,
                 from /home/lin/netfilter-spooftcp/xt_SPOOFTCP.c:7:
/home/lin/netfilter-spooftcp/xt_SPOOFTCP.c: In function ‘spooftcp_tg4’:
./include/linux/skbuff.h:3375:6: warning: ‘otcph’ may be used uninitialized in this function [-Wmaybe-uninitialized]
      skb_copy_bits(skb, offset, buffer, len) < 0)
      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/lin/netfilter-spooftcp/xt_SPOOFTCP.c:98:17: note: ‘otcph’ was declared here
  struct tcphdr *otcph;
                 ^~~~~
  Building modules, stage 2.
  MODPOST 1 modules
```

in function `skb_header_pointer`, It seems that the data can be copied to the `buffer`. But `otcph`  looks like a wild pointer!

```
static inline void * __must_check
__skb_header_pointer(const struct sk_buff *skb, int offset,
		     int len, void *data, int hlen, void *buffer)
{
	if (hlen - offset >= len)
		return data + offset;

	if (!skb ||
	    skb_copy_bits(skb, offset, buffer, len) < 0)
		return NULL;

	return buffer;
}

static inline void * __must_check
skb_header_pointer(const struct sk_buff *skb, int offset, int len, void *buffer)
{
	return __skb_header_pointer(skb, offset, len, skb->data,
				    skb_headlen(skb), buffer);
}
```

So I am creating this pull request. Please take a few minutes to look at it. Finally, thank you for your efforts in this project.